### PR TITLE
Adapt to change to mavenCI step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,9 @@ clientsTemplate{
 
       if (utils.isCI()) {
 
-        def version = mavenCI{}
+        def version = mavenCI {
+            goal = "deploy"
+        }
         // hard coded for now
         def mvnRepo = "https://nexus.cd.test.fabric8.io/content/repositories/staging"
         def message = "PR now available for testing: https://openshift.io/_profile/_tenant?teamVersion=${version}&mavenRepo=${mvnRepo}"


### PR DESCRIPTION
Recently a change was introduced to mavenCI step which runs
goal instead of , this breaks testing PR as artifacts won't be
uploaded to nexus.

This patch fixes the issue by overriding the goal to .

For details about the changes to mavenCI and mavenCanaryRelease
See: fabric8io/fabric8-pipeline-library#418