### PR TITLE
Deprecate this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# WARNING: This project has been deprecated
+
+The template management has been moved directly to [fabric8-tenant](https://github.com/fabric8-services/fabric8-tenant) repository. Any additional changes in the templates should be done in the repo and not here.
+Files that were originally managed/produced by this repo can be found here:
+
+* [fabric8-tenant-deploy.yml](https://github.com/fabric8-services/fabric8-tenant/blob/master/environment/templates/fabric8-tenant-deploy.yml) for both run and stage
+* [fabric8-tenant-user.yml](https://github.com/fabric8-services/fabric8-tenant/blob/master/environment/templates/fabric8-tenant-user.yml)
+
 # fabric8-tenant-team
 
 to test YAML changes on PRs see https://github.com/fabric8-services/fabric8-tenant#testing-yaml


### PR DESCRIPTION
This PR adds a README info about the project deprecation ([PR](https://github.com/fabric8-services/fabric8-tenant/pull/634) that moves templates to [fabric8-tenant](https://github.com/fabric8-services/fabric8-tenant/) repo has been merged)